### PR TITLE
Update search path in configmake.h to Windows relative path

### DIFF
--- a/src/configmake.h
+++ b/src/configmake.h
@@ -1,4 +1,4 @@
-#define PKGDATADIR "/usr/local/share/enchant"
-#define PKGLIBDIR "/usr/local/lib/enchant"
-#define SYSCONFDIR "/usr/local/etc"
-#define INSTALLPREFIX "/usr/local"
+#define PKGDATADIR "share\\enchant"
+#define PKGLIBDIR "lib\\enchant"
+#define SYSCONFDIR "etc"
+#define INSTALLPREFIX "."


### PR DESCRIPTION
The current search paths start with "/usr/local", which is an illegal path on Windows.
That means enchant will not be able to find any broker or dict, resulting in enchant_broker_describe() and enchant_broker_list_dicts() always return empty array in php.

I replace them with relative paths, so that they can work with the file structure of the current release tarball.
```
- php.exe
-- lib\enchant-2\libenchant2_hunspell.dll
-- share\enchant\hunspell\en_US.aff
-- share\enchant\hunspell\en_US.dic
```